### PR TITLE
Fix typo in annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ spec:
   template:
     metadata:
       annotations:
-        scheduler.alpha.Kubernetes.io/critical-pod: ""
+        scheduler.alpha.kubernetes.io/critical-pod: ""
       labels:
         k8s-app: sgx-device-plugin
     spec:

--- a/deploy/sgx-device-plugin.yml
+++ b/deploy/sgx-device-plugin.yml
@@ -10,7 +10,7 @@ spec:
   template:
     metadata:
       annotations:
-        scheduler.alpha.Kubernetes.io/critical-pod: ""
+        scheduler.alpha.kubernetes.io/critical-pod: ""
       labels:
         k8s-app: sgx-device-plugin
     spec:


### PR DESCRIPTION
`scheduler.alpha.Kubernetes.io/critical-pod` -> `scheduler.alpha.kubernetes.io/critical-pod`

Reference: https://v1-14.docs.kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/#marking-pod-as-critical