### PR TITLE
[Feature] Add AESM socket attachment support

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,9 @@ spec:
         alibabacloud.com/sgx_epc_MiB: 20
 ```
 
-If you want a remote attestation, you should mount `/var/run/aesmd/aesm.socket` in your container, maybe like this:
+If you want a remote attestation, aesm.socket MUST BE mounted inside application containers. There are two ways to achieve it:
+
+Way 1: Mount aesm.socket (i.e. /var/run/aesmd/aesm.socket) inside your application containers manually, maybe like this:
 
 ```yaml
 apiVersion: v1
@@ -171,6 +173,8 @@ spec:
     name: aesmsocket
 
 ```
+
+Way 2: Enable AESM socket attachment of sgx-device-plugin (via --enable-aesm-socket-attach=true) which will help you mount ASEM socket inside your application containers automatically. See deploy/sgx-device-plugin-enable-aesm.yml.
 
 ## FAQ
 

--- a/cmd/sgx-device-plugin/main.go
+++ b/cmd/sgx-device-plugin/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"syscall"
 
 	"github.com/fsnotify/fsnotify"
@@ -12,7 +13,13 @@ import (
 	"github.com/AliyunContainerService/sgx-device-plugin/pkg/utils"
 )
 
+func init() {
+	flag.BoolVar(&sgx.EnableAESMSocketAttach, "enable-aesm-socket-attach", false, "Enables attachment of AESM service socket")
+}
+
 func main() {
+	flag.Parse()
+
 	klog.Infof("Detecting SGX devices ...")
 	if len(sgx.GetDevices()) == 0 {
 		panic("No Device Found.")

--- a/deploy/sgx-device-plugin-enable-aesm.yml
+++ b/deploy/sgx-device-plugin-enable-aesm.yml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: sgx-device-plugin-ds
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: sgx-device-plugin
+  template:
+    metadata:
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+      labels:
+        k8s-app: sgx-device-plugin
+    spec:
+      containers:
+        - image: registry.cn-hangzhou.aliyuncs.com/acs/sgx-device-plugin:v1.0.0-fb467e2-aliyun
+          imagePullPolicy: IfNotPresent
+          name: sgx-device-plugin
+          args: ["--enable-aesm-socket-attach"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - mountPath: /var/lib/kubelet/device-plugins
+              name: device-plugin
+            - mountPath: /var/run/aesmd
+              name: aesm
+            - mountPath: /dev
+              name: dev
+      tolerations:
+        - effect: NoSchedule
+          key: alibabacloud.com/sgx_epc_MiB
+          operator: Exists
+      volumes:
+        - hostPath:
+            path: /var/lib/kubelet/device-plugins
+            type: DirectoryOrCreate
+          name: device-plugin
+        - hostPath:
+            path: /var/run/aesmd
+            type: Directory
+          name: aesm
+        - hostPath:
+            path: /dev
+            type: Directory
+          name: dev


### PR DESCRIPTION
This patch enables the AESM support for sgx-device-plugin. SGX container
applications using sgx-device-plugin are now able to automatically mount the
host AESM service.

A switch option --enable-aesm-socket-attach to enable/disable this feature is
provided at the cmdline level.

Signed-off-by: Kailun Qin <kailun.qkl@antfin.com>