### PR TITLE
[Feature] Add SGX unix socket detection support

### DIFF
--- a/cmd/sgx-device-plugin/main.go
+++ b/cmd/sgx-device-plugin/main.go
@@ -57,6 +57,10 @@ L:
 				klog.Infof("Inotify: %s created, restarting ...", devicepluginapi.KubeletSocket)
 				restart = true
 			}
+			if event.Name == deviceplugin.ServerSock && event.Op&fsnotify.Remove == fsnotify.Remove {
+				klog.Infof("Inotify: %s removed, restarting ...", deviceplugin.ServerSock)
+				restart = true
+			}
 
 		case err := <-watcher.Errors:
 			klog.Infof("inotify: %s", err)

--- a/pkg/device_plugin/server.go
+++ b/pkg/device_plugin/server.go
@@ -21,7 +21,7 @@ const (
 	// ResourceNameSGX is resource name registered to kubelet.
 	ResourceNameSGX = vendor + "/sgx_epc_MiB"
 
-	serverSock             = devicepluginapi.DevicePluginPath + "/sgx.sock"
+	ServerSock             = devicepluginapi.DevicePluginPath + "sgx.sock"
 	envDisableHealthChecks = "DP_DISABLE_HEALTHCHECKS"
 	allHealthChecks        = "xids"
 
@@ -42,7 +42,7 @@ func NewSGXDevicePlugin() (*SGXDevicePlugin, error) {
 
 	return &SGXDevicePlugin{
 		devs:   devs,
-		socket: serverSock,
+		socket: ServerSock,
 
 		stop:   make(chan interface{}),
 		health: make(chan *devicepluginapi.Device),


### PR DESCRIPTION
In the current implementation, a new kubelet instance deletes all the existing
unix sockets under /var/lib/kubelet/device-plugins when it starts. Besides, the
SGX unix socket can be accidentally removed during ops.

To this end, we're proposing in this patch a detection mechanism for SGX device
plugin that will monitor the deletion of SGX unix socket, re-start the device
plugin grpc server and re-register itself with kubelet instance upon such an
event.

Signed-off-by: Kailun Qin <kailun.qkl@antfin.com>