### PR TITLE
[Feature] Add in-tree SGX driver support

### DIFF
--- a/pkg/device_plugin/server.go
+++ b/pkg/device_plugin/server.go
@@ -31,8 +31,12 @@ const (
 // NewSGXDevicePlugin returns an initialized SGXDevicePlugin
 func NewSGXDevicePlugin() (*SGXDevicePlugin, error) {
 	drivers := sgx.AllDeviceDrivers()
-	if _, ok := drivers["/dev/isgx"]; !ok {
-		return nil, errors.New("/dev/isgx not found")
+	if !drivers["/dev/isgx"] && !drivers["/dev/sgx"] {
+		return nil, errors.New("either /dev/isgx or /dev/sgx not found")
+	}
+
+	if drivers["/dev/isgx"] && drivers["/dev/sgx"] {
+		return nil, errors.New("neither /dev/isgx nor /dev/sgx found")
 	}
 
 	devs := sgx.GetDevices()

--- a/pkg/sgx/sgx.go
+++ b/pkg/sgx/sgx.go
@@ -30,7 +30,8 @@ func AllMountPoints() map[string]bool {
 }
 
 var allDeviceDrivers = map[string]bool{
-	"/dev/isgx": false, // required
+	"/dev/isgx": false, // required out-of-tree sgx driver
+	"/dev/sgx":  false, // alternative in-tree sgx driver
 	"/dev/gsgx": false, // optional
 }
 


### PR DESCRIPTION
The kernel in-tree SGX driver provides the device node /dev/sgx against
the out-of-tree SGX driver supplying /dev/isgx.

In either case, the device node must exist, except that both of them
exist under a wrong system configuration.

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>