### PR TITLE
Fix compile error of Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,16 @@
-FROM centos:7
+FROM registry.cn-hangzhou.aliyuncs.com/alinux/alinux3 as builder
 
-COPY _output/sgx-device-plugin /usr/bin/sgx-device-plugin
+ARG GOVER=1.21.0
+ARG GOPROXY=https://mirrors.aliyun.com/goproxy/,direct
+
+RUN yum install -y wget tar make && yum clean all && \
+	wget https://mirrors.aliyun.com/golang/go${GOVER}.linux-amd64.tar.gz && tar -C /usr/local -xzf go${GOVER}.linux-amd64.tar.gz
+
+WORKDIR /src
+ADD . /src
+RUN export PATH=/usr/local/go/bin:$PATH && make
+
+FROM registry.cn-hangzhou.aliyuncs.com/alinux/alinux3 as image
+COPY --from=builder /src/_output/sgx-device-plugin /usr/bin/sgx-device-plugin
 
 ENTRYPOINT ["/usr/bin/sgx-device-plugin"]


### PR DESCRIPTION
Current code base will emit following compile error message:
```
$ docker build . -f Dockerfile
[+] Building 3.7s (6/6) FINISHED                                                                                                                                                                                                             docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                   0.0s
 => => transferring dockerfile: 153B                                                                                                                                                                                                                   0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                      0.0s
 => => transferring context: 2B                                                                                                                                                                                                                        0.0s
 => [internal] load metadata for docker.io/library/centos:7                                                                                                                                                                                            3.7s
 => [internal] load build context                                                                                                                                                                                                                      0.0s
 => => transferring context: 2B                                                                                                                                                                                                                        0.0s
 => [1/2] FROM docker.io/library/centos:7@sha256:be65f488b7764ad3638f236b7b515b3678369a5124c47b8d32916d6487418ea4                                                                                                                                      0.0s
 => => resolve docker.io/library/centos:7@sha256:be65f488b7764ad3638f236b7b515b3678369a5124c47b8d32916d6487418ea4                                                                                                                                      0.0s
 => ERROR [2/2] COPY _output/sgx-device-plugin /usr/bin/sgx-device-plugin                                                                                                                                                                              0.0s
------
 > [2/2] COPY _output/sgx-device-plugin /usr/bin/sgx-device-plugin:
------
Dockerfile:3
--------------------
   1 |     FROM centos:7
   2 |
   3 | >>> COPY _output/sgx-device-plugin /usr/bin/sgx-device-plugin
   4 |
   5 |     ENTRYPOINT ["/usr/bin/sgx-device-plugin"]
--------------------
ERROR: failed to solve: failed to compute cache key: failed to calculate checksum of ref 061e7016-d04c-4f35-a734-42d2ff8e3981::lrfmoo4kz5vbx6ez1b7l4g6iw: failed to walk /var/lib/docker/tmp/buildkit-mount2315372099/_output: lstat /var/lib/docker/tmp/buildkit-mount2315372099/_output: no such file or directory 
```
